### PR TITLE
Implementing found changes for filtering issues

### DIFF
--- a/components/clientCarePlans.js
+++ b/components/clientCarePlans.js
@@ -25,7 +25,7 @@ function ClientCarePlans({user, viewingUser, viewingUserData}) {
                 return (
                     <ReferralContainer key={item._id} item={item} user={viewingUser} notes={viewingUserData.notes}
                                        loggedInUser={user}
-                                       tasks={viewingUserData.tasks}
+                                       tasks={viewingUserData.tasks.filter((task) => task.referralId === item._id)}
                                        modifier={user.email}
                                        setUserReferrals={setUserReferrals}/>
                 )

--- a/components/referralContainer.js
+++ b/components/referralContainer.js
@@ -17,17 +17,17 @@ function ReferralContainer({item, user, notes, setUserReferrals, modifier, logge
     async function saveTask() {
         await setSaving("saving");
 
-        // Create a new task object to immediately update the UI
-        // const newTask = {
-        //     _id: Date.now().toString(), // Temporary ID until we get the real one from the server
-        //     referralId: item._id,
-        //     userId: user._id,
-        //     task: task,
-        //     surveyId: item.surveyId,
-        //     timestamp: new Date(),
-        //     modifiedBy: modifier,
-        //     completed: "false"
-        // };
+         //Create a new task object to immediately update the UI
+         const newTask = {
+             _id: Date.now().toString(), // Temporary ID until we get the real one from the server
+             referralId: item._id,
+             userId: user._id,
+             task: task,
+             surveyId: item.surveyId,
+             timestamp: new Date(),
+             modifiedBy: modifier,
+             completed: "false"
+         };
 
         // Immediately update the task state with the new task
         // setTasks(prevTasks => [...prevTasks, newTask]);

--- a/components/referralContainer.js
+++ b/components/referralContainer.js
@@ -18,18 +18,18 @@ function ReferralContainer({item, user, notes, setUserReferrals, modifier, logge
         await setSaving("saving");
 
         // Create a new task object to immediately update the UI
-        const newTask = {
-            _id: Date.now().toString(), // Temporary ID until we get the real one from the server
-            referralId: item._id,
-            userId: user._id,
-            task: task,
-            surveyId: item.surveyId,
-            timestamp: new Date(),
-            modifiedBy: modifier,
-            completed: "false"
-        };
+        // const newTask = {
+        //     _id: Date.now().toString(), // Temporary ID until we get the real one from the server
+        //     referralId: item._id,
+        //     userId: user._id,
+        //     task: task,
+        //     surveyId: item.surveyId,
+        //     timestamp: new Date(),
+        //     modifiedBy: modifier,
+        //     completed: "false"
+        // };
 
-        // Immediately update the tasks state with the new task
+        // Immediately update the task state with the new task
         // setTasks(prevTasks => [...prevTasks, newTask]);
 
         const data = await fetch("/api/save-task", {
@@ -81,7 +81,7 @@ function ReferralContainer({item, user, notes, setUserReferrals, modifier, logge
         const data = await fetch("/api/get-referrals?userId=" + user._id)
         const res = await data.json()
         if (res.success) {
-            await setUserReferrals(fetchedReferrals)
+            await setUserReferrals(res)
             await setSaving("false")
         }else {
             await setSaving("error")

--- a/pages/api/get-clients.js
+++ b/pages/api/get-clients.js
@@ -9,10 +9,25 @@ export default async (req, res) => {
     const cursor = await db.collection("users").find({
         coach: {
             $elemMatch: {
-                _id: coachObjectId,
-                $and: [
-                    { $or: [{ terminationDate: { $exists: false } }, { terminationDate: null }] },
-                    { $or: [{ removalDate: { $exists: false } }, { removalDate: null }] }
+                $or: [
+                    {
+
+                
+                        _id: coachObjectId,
+                        $and: [
+                            { $or: [{ terminationDate: { $exists: false } }, { terminationDate: null }] },
+                            { $or: [{ removalDate: { $exists: false } }, { removalDate: null }] }
+                        ]
+                    },
+                    {
+
+                
+                        key: coachObjectId,
+                        $and: [
+                            { $or: [{ terminationDate: { $exists: false } }, { terminationDate: null }] },
+                            { $or: [{ removalDate: { $exists: false } }, { removalDate: null }] }
+                        ]
+                    }
                 ]
             }
         }

--- a/pages/api/get-referrals.js
+++ b/pages/api/get-referrals.js
@@ -6,11 +6,11 @@ export default async (req, res) => {
     let q
     if (req.query.surveyId === undefined) {
         q = {
-            userId: ObjectId(req.query.userId),
+            userId: new ObjectId(req.query.userId),
         }
     } else {
         q = {
-            userId: ObjectId(req.query.userId),
+            userId: new ObjectId(req.query.userId),
             surveyId: req.query.surveyId
         }
     }
@@ -27,7 +27,7 @@ export default async (req, res) => {
 
 
 
-    const allRecords = await records.concat(customRecords)
+    const allRecords = records.concat(customRecords)
 
     res.json(allRecords)
 

--- a/pages/api/get-referrals.js
+++ b/pages/api/get-referrals.js
@@ -6,11 +6,11 @@ export default async (req, res) => {
     let q
     if (req.query.surveyId === undefined) {
         q = {
-            userId: new ObjectId(req.query.userId),
+            userId: ObjectId(req.query.userId),
         }
     } else {
         q = {
-            userId: new ObjectId(req.query.userId),
+            userId: ObjectId(req.query.userId),
             surveyId: req.query.surveyId
         }
     }
@@ -27,7 +27,7 @@ export default async (req, res) => {
 
 
 
-    const allRecords = records.concat(customRecords)
+    const allRecords = await records.concat(customRecords)
 
     res.json(allRecords)
 

--- a/pages/api/get-tasks.js
+++ b/pages/api/get-tasks.js
@@ -5,7 +5,7 @@ import {ObjectId} from 'mongodb'
 export default async (req, res) => {
     let q = {
         userId: new ObjectId(req.query.userId),
-        // referralId: req.query.referralId
+        referralId: req.query.referralId
     }
 
     const {db} = await connectToDatabase()

--- a/pages/api/removeCoach.js
+++ b/pages/api/removeCoach.js
@@ -23,7 +23,18 @@ export default async function handler(req, res) {
         const result = await collection.updateOne(
             {
                 _id: userSearchId,
-                coach: {$elemMatch: {_id: coachObjectId}},
+                coach: {
+                    $elemMatch: {
+                        $or: [
+                            {
+                                _id: coachObjectId
+                            },
+                            {
+                                key: coachObjectId
+                            }
+                        ]
+                    }
+                }
             },
             {
                 $set: { 'coach.$[elem].removalDate': new Date() }


### PR DESCRIPTION
Implementing changes based on mine and drew's digging into the current bugs in coach/client display and deletion issues.

Implementing a filter on the tasks list on the CarePlan page
Implementing an $or for searching the database, to find both coaches with a "key" and coaches with an "_id" to enable deleting of old coaches
Implementing an $or for searching the database to find both clients with the current user's "key" and current user's "ID" as their coach.